### PR TITLE
Add MSSQL syntax and SCHEMA syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You need to set up some information in your `box.json`:
 ```json
 "cfmigrations": {
     "defaultGrammar": "BaseGrammar",
-    "schema": "${DB_DATABASE}",
+    "schema": "${DB_SCHEMA}",
     "connectionInfo": {
         "class": "${DB_CLASS}",
         "connectionString": "${DB_CONNECTIONSTRING}",
@@ -66,12 +66,25 @@ For local development using CommandBox, I recommend using the package [`commandb
 With `commandbox-dotenv` installed, create a `.env` file in the root of you project. At the very least, it will look like this:
 
 ```
+# MYSQL VERSION
+DB_SCHEMA=test_db
 DB_DATABASE=test_db
 DB_CLASS=org.gjt.mm.mysql.Driver
 DB_CONNECTIONSTRING=jdbc:mysql://localhost:3306/test_db?useUnicode=true&characterEncoding=UTF-8&useLegacyDatetimeCode=true
 DB_USER=test
 DB_PASSWORD=pass1234
 ```
+
+```
+# MSSQL VERSION
+DB_SCHEMA=dbo
+DB_DATABASE=test_db
+DB_CLASS=com.microsoft.sqlserver.jdbc.SQLServerDriver
+DB_CONNECTIONSTRING=jdbc:sqlserver://localhost:1433;DATABASENAME=test_db;sendStringParametersAsUnicode=true;SelectMethod=direct
+DB_USER=test
+DB_PASSWORD=pass1234
+```
+
 
 I recommend adding this file to your `.gitignore`
 
@@ -82,6 +95,7 @@ I recommend adding this file to your `.gitignore`
 An added step to help new users get up to speed with the needed environment variables for your project is to add an `.env.example` file to the root of your project as well. This file would have all the keys needed, but no values filled out. Like so:
 
 ```
+DB_SCHEMA=
 DB_DATABASE=
 DB_CLASS=
 DB_CONNECTIONSTRING=


### PR DESCRIPTION
Adding a MSSQL example in addition to the MySQL version will be useful for quick reference.
This will save people a lot of time to guess what is needed for MSSQL.

I think using the DB_DATABASE name for the schema is misleading, although valid in MySQL, this change of using a variable named DB_SCHEMA and adding that with an example of the `dbo` required for MSSQL should be helpful.