### PR TITLE
Add a default migrationsDirectory to box.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ You need to set up some information in your `box.json`:
         "password": "${DB_PASSWORD}", 
         "bundleName": "${DB_BUNDLENAME}", 
         "bundleVersion": "${DB_BUNDLEVERSION}"
-    }
+    },
+   "migrationsDirectory": "resources/database/migrations"
 }
 ```
 
@@ -37,6 +38,8 @@ be unable to correct detect the migrations table.  It may tell you that the migr
 already installed when it isn't because it detects it in a different schema.
 
 The `connectionInfo` object is the information to create an on the fly connection in CommandBox to run your migrations. This is the same struct you would use to add an application datasource in Lucee. (Note: it must be Lucee compatible since that is what CommandBox runs on under-the-hood.)
+
+The `migrationsDirectory` sets the default location for the migration scripts.  This setting is optional.
 
 > When using MySQL with CommandBox 5 or greater, two additional elements are required in the `connectionInfo` struct:
 > `"bundleName":"com.mysql.cj"` and `"bundleVersion":"8.0.15"`

--- a/commands/migrate/down.cfc
+++ b/commands/migrate/down.cfc
@@ -5,20 +5,18 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
     * @once                Only rollback a single migration.
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
         boolean once = false,
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         try {
             checkForInstalledMigrationTable();

--- a/commands/migrate/fresh.cfc
+++ b/commands/migrate/fresh.cfc
@@ -4,19 +4,17 @@
 component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         command( "migrate reset" )
             .params( argumentCollection = arguments )

--- a/commands/migrate/init.cfc
+++ b/commands/migrate/init.cfc
@@ -30,7 +30,8 @@ component {
             "cfmigrations.connectionInfo.class": "${DB_CLASS}",
             "cfmigrations.connectionInfo.connectionString": "${DB_CONNECTIONSTRING}",
             "cfmigrations.connectionInfo.username": "${DB_USER}",
-            "cfmigrations.connectionInfo.password": "${DB_PASSWORD}"
+            "cfmigrations.connectionInfo.password": "${DB_PASSWORD}",
+            "cfmigrations.migrationsDirectory": "resources/database/migrations"
         }, false );
 
 		// Write the file back out.

--- a/commands/migrate/refresh.cfc
+++ b/commands/migrate/refresh.cfc
@@ -4,19 +4,17 @@
 component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         command( "migrate down" )
             .params( argumentCollection = { verbose = arguments.verbose } )

--- a/commands/migrate/reset.cfc
+++ b/commands/migrate/reset.cfc
@@ -4,19 +4,17 @@
 component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         try {
             migrationService.reset();

--- a/commands/migrate/uninstall.cfc
+++ b/commands/migrate/uninstall.cfc
@@ -7,21 +7,19 @@
 component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     * @force               If true, will not wait for confirmation to uninstall cfmigrations.
     */
     function run(
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false,
         boolean force = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         try {
             if ( ! migrationService.isMigrationTableInstalled() ) {

--- a/commands/migrate/up.cfc
+++ b/commands/migrate/up.cfc
@@ -5,12 +5,12 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
     * @once                Only apply a single migration.
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
         boolean once = false,
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
@@ -21,10 +21,8 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         }
 
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         try {
             checkForInstalledMigrationTable();

--- a/models/BaseMigrationCommand.cfc
+++ b/models/BaseMigrationCommand.cfc
@@ -16,6 +16,15 @@ component {
         migrationService.setDatasource( "cfmigrations" );
         param cfmigrationsInfo.schema = "";
         migrationService.setSchema( cfmigrationsInfo.schema );
+        param cfmigrationsInfo.migrationsDirectory = "resources/database/migrations";
+        setMigrationPath( cfmigrationsInfo.migrationsDirectory );
+    }
+
+    function setMigrationPath ( required migrationsDirectory ){
+        var relativePath = fileSystemUtil.makePathRelative(
+            fileSystemUtil.resolvePath( migrationsDirectory )
+        );
+        migrationService.setMigrationsDirectory( relativePath );
     }
 
     private function checkForInstalledMigrationTable() {


### PR DESCRIPTION
We're using commandbox-migrations to apply migrations that aren't in the default migrationDirectory and rather than enter the new directory every time we use a command, I've made the command line the override.

By adding this key to the cfmigrations section of the box.json, we're also making it more obvious to those who use it where there scripts are going to be.  This is also handy if we need to change it in another environment.

I also refactored some repeated code from the actions  to the base class.

This change shouldn't affect existing users.
