### PR TITLE
Default migrations directory refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ You need to set up some information in your `box.json`:
         "password": "${DB_PASSWORD}", 
         "bundleName": "${DB_BUNDLENAME}", 
         "bundleVersion": "${DB_BUNDLEVERSION}"
-    }
+    },
+   "migrationsDirectory": "resources/database/migrations"
 }
 ```
 
@@ -37,6 +38,8 @@ be unable to correct detect the migrations table.  It may tell you that the migr
 already installed when it isn't because it detects it in a different schema.
 
 The `connectionInfo` object is the information to create an on the fly connection in CommandBox to run your migrations. This is the same struct you would use to add an application datasource in Lucee. (Note: it must be Lucee compatible since that is what CommandBox runs on under-the-hood.)
+
+The `migrationsDirectory` sets the default location for the migration scripts.  This setting is optional.
 
 > When using MySQL with CommandBox 5 or greater, two additional elements are required in the `connectionInfo` struct:
 > `"bundleName":"com.mysql.cj"` and `"bundleVersion":"8.0.15"`

--- a/commands/migrate/create.cfc
+++ b/commands/migrate/create.cfc
@@ -5,28 +5,32 @@
 * It prepends the date at the beginning of the file name so
 * you can keep your migrations in the correct order.
 */
-component {
+component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
     * @name Name of the migration to create without the .cfc.
-    * @directory The base directory to create your migration in. Creates the directory if it does not exist.
+    * @migrationsDirectory The base migrationsDirectory to create your migration in. Creates the migrationsDirectory if it does not exist.
     * @open Open the file once generated
     */
     function run(
         required string name,
-        string directory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean open = false
     ) {
-        // This will make each directory canonical and absolute
-        arguments.directory = fileSystemUtil.resolvePath( arguments.directory );
+        setup();
 
-        // Validate directory
-        if( !directoryExists( arguments.directory ) ) {
-            directoryCreate( arguments.directory );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( arguments.migrationsDirectory );
+        
+        arguments.migrationsDirectory =  getMigrationPath();
+
+        // Validate migrationsDirectory
+        if( !directoryExists( arguments.migrationsDirectory ) ) {
+            directoryCreate( arguments.migrationsDirectory );
         }
 
         var timestamp = dateTimeFormat( now(), "yyyy_mm_dd_HHnnss" );
-        var migrationPath = "#arguments.directory#/#timestamp#_#arguments.name#.cfc";
+        var migrationPath = "#arguments.migrationsDirectory#/#timestamp#_#arguments.name#.cfc";
 
         var migrationContent = fileRead( "/commandbox-migrations/templates/Migration.txt" );
 

--- a/commands/migrate/down.cfc
+++ b/commands/migrate/down.cfc
@@ -16,7 +16,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         try {
             checkForInstalledMigrationTable();

--- a/commands/migrate/down.cfc
+++ b/commands/migrate/down.cfc
@@ -5,20 +5,18 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
     * @once                Only rollback a single migration.
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
         boolean once = false,
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         try {
             checkForInstalledMigrationTable();

--- a/commands/migrate/fresh.cfc
+++ b/commands/migrate/fresh.cfc
@@ -14,7 +14,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         command( "migrate reset" )
             .params( argumentCollection = arguments )

--- a/commands/migrate/fresh.cfc
+++ b/commands/migrate/fresh.cfc
@@ -4,19 +4,17 @@
 component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         command( "migrate reset" )
             .params( argumentCollection = arguments )

--- a/commands/migrate/init.cfc
+++ b/commands/migrate/init.cfc
@@ -30,7 +30,8 @@ component {
             "cfmigrations.connectionInfo.class": "${DB_CLASS}",
             "cfmigrations.connectionInfo.connectionString": "${DB_CONNECTIONSTRING}",
             "cfmigrations.connectionInfo.username": "${DB_USER}",
-            "cfmigrations.connectionInfo.password": "${DB_PASSWORD}"
+            "cfmigrations.connectionInfo.password": "${DB_PASSWORD}",
+            "cfmigrations.migrationsDirectory": "resources/database/migrations"
         }, false );
 
 		// Write the file back out.

--- a/commands/migrate/refresh.cfc
+++ b/commands/migrate/refresh.cfc
@@ -14,7 +14,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         command( "migrate down" )
             .params( argumentCollection = { verbose = arguments.verbose } )

--- a/commands/migrate/refresh.cfc
+++ b/commands/migrate/refresh.cfc
@@ -4,19 +4,17 @@
 component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         command( "migrate down" )
             .params( argumentCollection = { verbose = arguments.verbose } )

--- a/commands/migrate/reset.cfc
+++ b/commands/migrate/reset.cfc
@@ -14,7 +14,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         try {
             migrationService.reset();

--- a/commands/migrate/reset.cfc
+++ b/commands/migrate/reset.cfc
@@ -4,19 +4,17 @@
 component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         try {
             migrationService.reset();

--- a/commands/migrate/uninstall.cfc
+++ b/commands/migrate/uninstall.cfc
@@ -19,7 +19,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         try {
             if ( ! migrationService.isMigrationTableInstalled() ) {

--- a/commands/migrate/uninstall.cfc
+++ b/commands/migrate/uninstall.cfc
@@ -7,21 +7,19 @@
 component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     * @force               If true, will not wait for confirmation to uninstall cfmigrations.
     */
     function run(
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false,
         boolean force = false
     ) {
         setup();
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         try {
             if ( ! migrationService.isMigrationTableInstalled() ) {

--- a/commands/migrate/up.cfc
+++ b/commands/migrate/up.cfc
@@ -5,12 +5,12 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
     * @once                Only apply a single migration.
-    * @migrationsDirectory Specify the relative location of the migration files
+    * @migrationsDirectory Override the default relative location of the migration files
     * @verbose             If true, errors output a full stack trace
     */
     function run(
         boolean once = false,
-        string migrationsDirectory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean verbose = false
     ) {
         setup();
@@ -21,10 +21,8 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         }
 
         pagePoolClear();
-        var relativePath = fileSystemUtil.makePathRelative(
-            fileSystemUtil.resolvePath( migrationsDirectory )
-        );
-        migrationService.setMigrationsDirectory( relativePath );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( migrationsDirectory );
 
         try {
             checkForInstalledMigrationTable();

--- a/commands/migrate/up.cfc
+++ b/commands/migrate/up.cfc
@@ -22,7 +22,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         try {
             checkForInstalledMigrationTable();

--- a/models/BaseMigrationCommand.cfc
+++ b/models/BaseMigrationCommand.cfc
@@ -27,6 +27,10 @@ component {
         migrationService.setMigrationsDirectory( relativePath );
     }
 
+    string function getMigrationPath ( ){
+        return migrationService.getMigrationsDirectory();
+    }
+
     private function checkForInstalledMigrationTable() {
         if ( ! migrationService.isMigrationTableInstalled() ) {
             if ( confirm( "Migration table not installed.  Do you want to install it now? [y\n]" ) ) {

--- a/models/BaseMigrationCommand.cfc
+++ b/models/BaseMigrationCommand.cfc
@@ -16,6 +16,15 @@ component {
         migrationService.setDatasource( "cfmigrations" );
         param cfmigrationsInfo.schema = "";
         migrationService.setSchema( cfmigrationsInfo.schema );
+        param cfmigrationsInfo.migrationsDirectory = "resources/database/migrations";
+        setMigrationPath( cfmigrationsInfo.migrationsDirectory );
+    }
+
+    function setMigrationPath ( required migrationsDirectory ){
+        var relativePath = fileSystemUtil.makePathRelative(
+            fileSystemUtil.resolvePath( migrationsDirectory )
+        );
+        migrationService.setMigrationsDirectory( relativePath );
     }
 
     private function checkForInstalledMigrationTable() {


### PR DESCRIPTION
I needed to modify Create to also respect the new migrationsDirectory default in box.json.

NOTE: I changed the create argument to match the rest of the commands ("migrationsDirectory" instead of simply "directory")