### PR TITLE
Default migrations directory hotfix

### DIFF
--- a/commands/migrate/create.cfc
+++ b/commands/migrate/create.cfc
@@ -5,28 +5,32 @@
 * It prepends the date at the beginning of the file name so
 * you can keep your migrations in the correct order.
 */
-component {
+component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
     /**
     * @name Name of the migration to create without the .cfc.
-    * @directory The base directory to create your migration in. Creates the directory if it does not exist.
+    * @migrationsDirectory The base migrationsDirectory to create your migration in. Creates the migrationsDirectory if it does not exist.
     * @open Open the file once generated
     */
     function run(
         required string name,
-        string directory = "resources/database/migrations",
+        string migrationsDirectory = "",
         boolean open = false
     ) {
-        // This will make each directory canonical and absolute
-        arguments.directory = fileSystemUtil.resolvePath( arguments.directory );
+        setup();
 
-        // Validate directory
-        if( !directoryExists( arguments.directory ) ) {
-            directoryCreate( arguments.directory );
+        if ( len(arguments.migrationsDirectory) )
+            setMigrationPath( arguments.migrationsDirectory );
+        
+        arguments.migrationsDirectory =  getMigrationPath();
+
+        // Validate migrationsDirectory
+        if( !directoryExists( arguments.migrationsDirectory ) ) {
+            directoryCreate( arguments.migrationsDirectory );
         }
 
         var timestamp = dateTimeFormat( now(), "yyyy_mm_dd_HHnnss" );
-        var migrationPath = "#arguments.directory#/#timestamp#_#arguments.name#.cfc";
+        var migrationPath = "#arguments.migrationsDirectory#/#timestamp#_#arguments.name#.cfc";
 
         var migrationContent = fileRead( "/commandbox-migrations/templates/Migration.txt" );
 

--- a/commands/migrate/down.cfc
+++ b/commands/migrate/down.cfc
@@ -16,7 +16,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         try {
             checkForInstalledMigrationTable();

--- a/commands/migrate/fresh.cfc
+++ b/commands/migrate/fresh.cfc
@@ -14,7 +14,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         command( "migrate reset" )
             .params( argumentCollection = arguments )

--- a/commands/migrate/refresh.cfc
+++ b/commands/migrate/refresh.cfc
@@ -14,7 +14,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         command( "migrate down" )
             .params( argumentCollection = { verbose = arguments.verbose } )

--- a/commands/migrate/reset.cfc
+++ b/commands/migrate/reset.cfc
@@ -14,7 +14,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         try {
             migrationService.reset();

--- a/commands/migrate/uninstall.cfc
+++ b/commands/migrate/uninstall.cfc
@@ -19,7 +19,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
         setup();
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         try {
             if ( ! migrationService.isMigrationTableInstalled() ) {

--- a/commands/migrate/up.cfc
+++ b/commands/migrate/up.cfc
@@ -22,7 +22,7 @@ component extends="commandbox-migrations.models.BaseMigrationCommand" {
 
         pagePoolClear();
         if ( len(arguments.migrationsDirectory) )
-            setMigrationPath( migrationsDirectory );
+            setMigrationPath( arguments.migrationsDirectory );
 
         try {
             checkForInstalledMigrationTable();

--- a/models/BaseMigrationCommand.cfc
+++ b/models/BaseMigrationCommand.cfc
@@ -27,6 +27,10 @@ component {
         migrationService.setMigrationsDirectory( relativePath );
     }
 
+    string function getMigrationPath ( ){
+        return migrationService.getMigrationsDirectory();
+    }
+
     private function checkForInstalledMigrationTable() {
         if ( ! migrationService.isMigrationTableInstalled() ) {
             if ( confirm( "Migration table not installed.  Do you want to install it now? [y\n]" ) ) {


### PR DESCRIPTION
I needed to modify Create to also respect the new migrationsDirectory default in box.json.

NOTE: I changed the create argument to match the rest of the commands ("migrationsDirectory" instead of simply "directory")