### PR TITLE
Update Migration.txt

### DIFF
--- a/templates/Migration.txt
+++ b/templates/Migration.txt
@@ -1,10 +1,10 @@
 component {
     
-    function up( schema, query ) {
+    function up( schema, qb ) {
         
     }
 
-    function down( schema, query ) {
+    function down( schema, qb ) {
         
     }
 


### PR DESCRIPTION
Currently, vscode syntax highlighting breaks when using cfformat.  https://github.com/jcberquist/commandbox-cfformat/issues/98  Changing this variable name should alleviate that problem.  

As this only affects new migrations, it shouldn't be a breaking change.  Anything other than a cf tag-in-script word should work if "qb" is too much of a departure.