### PR TITLE
Update to cfmgrations v5

### DIFF
--- a/box.json
+++ b/box.json
@@ -33,7 +33,7 @@
         }
     ],
     "dependencies":{
-        "cfmigrations":"^4.1.0",
+        "cfmigrations":"^5.0.0",
         "sqlformatter":"^1.1.3+31"
     },
     "installPaths":{


### PR DESCRIPTION
The cbmigrations dependency is stuck in an update loop during commandbox's update --system due the the changes in mockData dependency of the cfmigrations dependency.  From what I can see, the v5 for cfmigrations updates both cbMockData and qb.

Also, during the last update to this repo the box.json version number wasn't updated to 5.2.2 to match the GitHub tag also placing commandbox-migrations in a commandbox update loop.  Therefore, this will need to be bumped to 5.2.3 or 5.3 before release.